### PR TITLE
Write permission pv

### DIFF
--- a/pypiserver/CHANGELOG.md
+++ b/pypiserver/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.0.1]
+
+### Added
+
+- Bug fix: Setting fsGroup to 1000 in case of enabled persistence
+  (due to possibly missing write permissions as volumes are mounted as root owned folder by docker)
+
+### Changed
+
+### Removed

--- a/pypiserver/Chart.yaml
+++ b/pypiserver/Chart.yaml
@@ -1,6 +1,6 @@
 name: pypiserver
 home: https://github.com/pypiserver/pypiserver
-version: 1.0.0
+version: 1.0.1
 appVersion: 1.2.7
 description: PyPI compatible server for pip or easy_install.
 icon: https://raw.githubusercontent.com/pypiserver/pypiserver/master/pypiserver_logo.png

--- a/pypiserver/templates/deployment.yaml
+++ b/pypiserver/templates/deployment.yaml
@@ -25,6 +25,10 @@ spec:
         - name: {{ . }}
       {{- end }}
       {{- end }}
+      {{- if .Values.persistence.enabled }}
+      securityContext:
+        fsGroup: 1000
+      {{- end }}
       containers:
         - name: {{ template "pypiserver.name" . }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"


### PR DESCRIPTION
**Bug I had**

Volumes are mounted as root and the pypiserver cannot edit them.
See also: https://stackoverflow.com/questions/46769339/how-to-change-permission-of-mapped-volume-in-kubernetes-docker


**To Reproduce**
1. Have an AWS cluster
2. Apply the chart with persistence enabled
3. Try to upload a package
4. IOSError: no write permission /data/packages

**Environment**:
- Kubernetes version (use `kubectl version`): 1.12
- Cloud provider or hardware configuration: AWS EKS

**Fix**
I used the following fix (mostly form the stackoverflow link above)