### PR TITLE
Fix annotations, bumping pypiserver and cleanup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ addons:
       channel: stable
 
 before_script:
-  - helm init --client-only
+  - helm init 
 
 script:
   - helm lint $PACKAGE

--- a/pypiserver/CHANGELOG.md
+++ b/pypiserver/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.2.0]
+## [2.0.0]
+
+### Breaking Changes
+
+- `podLabels` deprecates `deployment.labels`
 
 ### Added
 

--- a/pypiserver/CHANGELOG.md
+++ b/pypiserver/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.0]
+
+### Added
+
+- Added `podAnnotations` and `podLabels` to deployment template
+- Added `apiVersion` to `Chart.yaml`
+
+### Changed
+
+- Bumped application version to `1.3.2`
+- Changed comment in `values.yaml`
+
 ## [1.1.0]
 
 ### Added

--- a/pypiserver/Chart.yaml
+++ b/pypiserver/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: pypiserver
 home: https://github.com/pypiserver/pypiserver
-version: 1.2.0
+version: 2.0.0
 appVersion: 1.3.2
 description: PyPI compatible server for pip or easy_install.
 icon: https://raw.githubusercontent.com/pypiserver/pypiserver/master/pypiserver_logo.png

--- a/pypiserver/Chart.yaml
+++ b/pypiserver/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 name: pypiserver
 home: https://github.com/pypiserver/pypiserver
-version: 1.1.0
-appVersion: 1.3.0
+version: 1.2.0
+appVersion: 1.3.2
 description: PyPI compatible server for pip or easy_install.
 icon: https://raw.githubusercontent.com/pypiserver/pypiserver/master/pypiserver_logo.png
 sources:

--- a/pypiserver/Chart.yaml
+++ b/pypiserver/Chart.yaml
@@ -1,3 +1,4 @@
+apiVersion: v1
 name: pypiserver
 home: https://github.com/pypiserver/pypiserver
 version: 1.1.0

--- a/pypiserver/README.md
+++ b/pypiserver/README.md
@@ -44,7 +44,7 @@ The following tables lists the configurable parameters of the PyPI server chart 
 | ---------------------------------- | ---------------------------------------------------------------------------------------- | ----------------------- |
 | `replicaCount`                     | Deployment replica count                                                                 | `1`                     |
 | `image.repository`                 | Container image repository                                                               | `pypiserver/pypiserver` |
-| `image.tag`                        | Container image name                                                                     | `v1.3.0`                |
+| `image.tag`                        | Container image name                                                                     | `v1.3.2`                |
 | `image.pullPolicy`                 | Container pull policy                                                                    | `IfNotPresent`          |
 | `image.pullSecrets`                | Container pull secrets                                                                   | `[]`                    |
 | `pypiserver.extraArgs`             | Additional arguments (beside -P, -p, -a) to be passed to the underyling pypiserver image | `[]`                    |

--- a/pypiserver/templates/deployment.yaml
+++ b/pypiserver/templates/deployment.yaml
@@ -21,8 +21,15 @@ spec:
       labels:
         app.kubernetes.io/name: {{ template "pypiserver.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
-        {{- if .Values.deployment.labels }}
-        {{- toYaml .Values.deployment.labels | nindent 8 }}
+        {{- if .Values.podLabels }}
+        {{- toYaml .Values.podLabels | nindent 8 }}
+        {{- end }}
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+        {{- if .Values.podAnnotations }}
+          {{- range $key, $value := .Values.podAnnotations }}
+            {{$key|quote}}: {{$value|quote}}
+          {{- end }}
         {{- end }}
     spec:
       {{- with .Values.image.pullSecrets }}

--- a/pypiserver/templates/deployment.yaml
+++ b/pypiserver/templates/deployment.yaml
@@ -7,9 +7,6 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     app.kubernetes.io/name: {{ template "pypiserver.name" . }}
-    {{- if .Values.deployment.labels }}
-    {{- toYaml .Values.deployment.labels | nindent 4 }}
-    {{- end }}
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:

--- a/pypiserver/templates/deployment.yaml
+++ b/pypiserver/templates/deployment.yaml
@@ -22,7 +22,7 @@ spec:
         {{- toYaml .Values.podLabels | nindent 8 }}
         {{- end }}
       annotations:
-        checksum/config: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+        checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
         {{- if .Values.podAnnotations }}
           {{- range $key, $value := .Values.podAnnotations }}
             {{$key|quote}}: {{$value|quote}}

--- a/pypiserver/values.yaml
+++ b/pypiserver/values.yaml
@@ -22,13 +22,9 @@ auth:
   ## use `htpasswd -n -b username password` to generate them
   credentials: {}
 
-deployment:
-  labels: {}
-
 podAnnotations: {}
 
 podLabels: {}
-
 
 ingress:
   enabled: false

--- a/pypiserver/values.yaml
+++ b/pypiserver/values.yaml
@@ -18,7 +18,7 @@ auth:
   ## Use '.' or '' for empty. Requires to have set the password (option below).
   ## Available actions are update, download and list
   actions: update
-  ## List of username / encoded passwords that will be put to the htpasswd file
+  ## Map of username / encoded passwords that will be put to the htpasswd file
   ## use `htpasswd -n -b username password` to generate them
   credentials: {}
 

--- a/pypiserver/values.yaml
+++ b/pypiserver/values.yaml
@@ -3,7 +3,7 @@ replicaCount: 1
 
 image:
   repository: pypiserver/pypiserver
-  tag: v1.3.0
+  tag: v1.3.2
   pullPolicy: IfNotPresent
   pullSecrets: []
 

--- a/pypiserver/values.yaml
+++ b/pypiserver/values.yaml
@@ -25,6 +25,11 @@ auth:
 deployment:
   labels: {}
 
+podAnnotations: {}
+
+podLabels: {}
+
+
 ingress:
   enabled: false
   labels: {}


### PR DESCRIPTION
**What this PR does / why we need it**:
- Adding podAnnotations and podLabels
- Removing deployment labels
- Bumping `pypiserver` version
- Adding `apiVersion` to `Chart.yaml`
- Rewording comment for `auth.credentials` map


**Checklist**:
- [x] Bumped chart version in Chart.yaml
- [x] Added an entry in the CHANGELOG.md