### PR TITLE
Fixup apiVersion for kube 1.16+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,6 @@ addons:
       confinement: classic
       channel: stable
 
-before_script:
-  - helm init 
-
 script:
   - helm lint $PACKAGE
 

--- a/pypiserver/CHANGELOG.md
+++ b/pypiserver/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.0]
+
+### Changed
+
+- Changed apiVersion of Deployment from extensions/v1beta1 to apps/v1 (not considered a breaking change as it's availble since v1.9)
+- Changed apiVersion of Ingress from extensions/v1beta1 to networking.k8s.io/v1beta1 (not considered a breaking change as it's availble since v1.14)
+- Fixing continuous integration
+
 ## [2.0.0]
 
 ### Breaking Changes

--- a/pypiserver/Chart.yaml
+++ b/pypiserver/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: pypiserver
 home: https://github.com/pypiserver/pypiserver
-version: 2.0.0
+version: 2.1.0
 appVersion: 1.3.2
 description: PyPI compatible server for pip or easy_install.
 icon: https://raw.githubusercontent.com/pypiserver/pypiserver/master/pypiserver_logo.png

--- a/pypiserver/templates/deployment.yaml
+++ b/pypiserver/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "pypiserver.fullname" . }}

--- a/pypiserver/templates/ingress.yaml
+++ b/pypiserver/templates/ingress.yaml
@@ -2,7 +2,7 @@
 {{- $fullName := include "pypiserver.fullname" . -}}
 {{- $servicePort := .Values.service.port -}}
 {{- $ingressPath := .Values.ingress.path -}}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: {{ $fullName }}


### PR DESCRIPTION
**What this PR does / why we need it**:
Kubernetes 1.16 deprecated some apiVersion. This Pull request update those apiVersions so it's ready for newer version of Kubernetes

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
This PR replaces the PRs #12 and #13 

**Checklist**:
- [x] Bumped chart version in Chart.yaml
- [x] Added an entry in the CHANGELOG.md
- [ ] ~Added an entry in the UPGRADE.md if this pull request creates a backward compatibility breaking change~
- [ ] ~Reference your chart in the build matrix of the .travis.yml (For new charts)~
