### PR TITLE
Add template configurations.

### DIFF
--- a/pypiserver/CHANGELOG.md
+++ b/pypiserver/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.2.0]
+
+### Changed
+
+- Allowed configuration of user and group
+- Allowed configuration of an external mount for packages
+
 ## [2.1.0]
 
 ### Changed

--- a/pypiserver/CHANGELOG.md
+++ b/pypiserver/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Allowed configuration of user and group
-- Allowed configuration of an external mount for packages
+- Allowed mountPropagation field configuration for a PV
 
 ## [2.1.0]
 

--- a/pypiserver/Chart.yaml
+++ b/pypiserver/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: pypiserver
 home: https://github.com/pypiserver/pypiserver
-version: 2.1.0
+version: 2.2.0
 appVersion: 1.3.2
 description: PyPI compatible server for pip or easy_install.
 icon: https://raw.githubusercontent.com/pypiserver/pypiserver/master/pypiserver_logo.png

--- a/pypiserver/README.md
+++ b/pypiserver/README.md
@@ -71,7 +71,7 @@ The following tables lists the configurable parameters of the PyPI server chart 
 | `persistence.accessMode`           | Persistence access mode                                                                  | `ReadWriteOnce`         |
 | `persistence.size`                 | Persistence volume size                                                                  | `5Gi`                   |
 | `persistence.mountPropagation`     | Mount propagation method                                                                 | `nil`                   |
-| `securityContext.enabled`          | Security context configuration flag                                                      | `0`                     |
+| `securityContext.enabled`          | Security context configuration flag                                                      | `true`                     |
 | `securityContext.runAsUser`        | User ID to run as                                                                        | `0`                     |
 | `securityContext.runAsGroup`       | Group ID to run as                                                                       | `0`                     |
 | `securityContext.fsGroup`          | Filesystem volume owner                                                                  | `1000`                  |

--- a/pypiserver/README.md
+++ b/pypiserver/README.md
@@ -74,7 +74,6 @@ The following tables lists the configurable parameters of the PyPI server chart 
 | `hostPathMount.path                | Host path to mount                                                                       |  nil                    |
 | `securityContext.runAsUser         | User ID to run as                                                                        |  0                      |
 | `securityContext.runAsGroup        | Group ID to run as                                                                       |  0                      |
-| `securityContext.privileged        | Whether to run as privileged user                                                        |  false                  |
 | `resources`                        | Resources configuration bloc                                                             | `{}`                    |
 | `nodeSelector`                     | Node selector of the deployment                                                          | `{}`                    |
 | `tolerations`                      | Tolerations configuration for the deployment                                             | `[]`                    |

--- a/pypiserver/README.md
+++ b/pypiserver/README.md
@@ -70,12 +70,11 @@ The following tables lists the configurable parameters of the PyPI server chart 
 | `persistence.existingClaim`        | Persistent volume claim static name                                                      | `nil`                   |
 | `persistence.accessMode`           | Persistence access mode                                                                  | `ReadWriteOnce`         |
 | `persistence.size`                 | Persistence volume size                                                                  | `5Gi`                   |
-| `hostPathMount.enabled             | Host directory mount configuration flag                                                  |  false                  |
-| `hostPathMount.path                | Host path to mount                                                                       |  nil                    |
-| `securityContext.enabled           | Security context configuration flag                                                      |  0                      |
-| `securityContext.runAsUser         | User ID to run as                                                                        |  0                      |
-| `securityContext.runAsGroup        | Group ID to run as                                                                       |  0                      |
-| `securityContext.fsGroup           | Filesystem volume owner                                                                  |  1000                   |
+| `persistence.mountPropagation`     | Mount propagation method                                                                 | `nil`                   |
+| `securityContext.enabled`          | Security context configuration flag                                                      | `0`                     |
+| `securityContext.runAsUser`        | User ID to run as                                                                        | `0`                     |
+| `securityContext.runAsGroup`       | Group ID to run as                                                                       | `0`                     |
+| `securityContext.fsGroup`          | Filesystem volume owner                                                                  | `1000`                  |
 | `resources`                        | Resources configuration bloc                                                             | `{}`                    |
 | `nodeSelector`                     | Node selector of the deployment                                                          | `{}`                    |
 | `tolerations`                      | Tolerations configuration for the deployment                                             | `[]`                    |

--- a/pypiserver/README.md
+++ b/pypiserver/README.md
@@ -70,8 +70,8 @@ The following tables lists the configurable parameters of the PyPI server chart 
 | `persistence.existingClaim`        | Persistent volume claim static name                                                      | `nil`                   |
 | `persistence.accessMode`           | Persistence access mode                                                                  | `ReadWriteOnce`         |
 | `persistence.size`                 | Persistence volume size                                                                  | `5Gi`                   |
-| `externalMount.enabled             | External mount configuration flag                                                        |  false                  |
-| `externalMount.path                | Path to external mount on host                                                           |  nil                    |
+| `hostPathMount.enabled             | Host directory mount configuration flag                                                  |  false                  |
+| `hostPathMount.path                | Host path to mount                                                                       |  nil                    |
 | `securityContext.runAsUser         | User ID to run as                                                                        |  0                      |
 | `securityContext.runAsGroup        | Group ID to run as                                                                       |  0                      |
 | `securityContext.privileged        | Whether to run as privileged user                                                        |  false                  |

--- a/pypiserver/README.md
+++ b/pypiserver/README.md
@@ -70,6 +70,11 @@ The following tables lists the configurable parameters of the PyPI server chart 
 | `persistence.existingClaim`        | Persistent volume claim static name                                                      | `nil`                   |
 | `persistence.accessMode`           | Persistence access mode                                                                  | `ReadWriteOnce`         |
 | `persistence.size`                 | Persistence volume size                                                                  | `5Gi`                   |
+| `externalMount.enabled             | External mount configuration flag                                                        |  false                  |
+| `externalMount.path                | Path to external mount on host                                                           |  nil                    |
+| `securityContext.runAsUser         | User ID to run as                                                                        |  0                      |
+| `securityContext.runAsGroup        | Group ID to run as                                                                       |  0                      |
+| `securityContext.privileged        | Whether to run as privileged user                                                        |  false                  |
 | `resources`                        | Resources configuration bloc                                                             | `{}`                    |
 | `nodeSelector`                     | Node selector of the deployment                                                          | `{}`                    |
 | `tolerations`                      | Tolerations configuration for the deployment                                             | `[]`                    |

--- a/pypiserver/README.md
+++ b/pypiserver/README.md
@@ -72,8 +72,10 @@ The following tables lists the configurable parameters of the PyPI server chart 
 | `persistence.size`                 | Persistence volume size                                                                  | `5Gi`                   |
 | `hostPathMount.enabled             | Host directory mount configuration flag                                                  |  false                  |
 | `hostPathMount.path                | Host path to mount                                                                       |  nil                    |
+| `securityContext.enabled           | Security context configuration flag                                                      |  0                      |
 | `securityContext.runAsUser         | User ID to run as                                                                        |  0                      |
 | `securityContext.runAsGroup        | Group ID to run as                                                                       |  0                      |
+| `securityContext.fsGroup           | Filesystem volume owner                                                                  |  1000                   |
 | `resources`                        | Resources configuration bloc                                                             | `{}`                    |
 | `nodeSelector`                     | Node selector of the deployment                                                          | `{}`                    |
 | `tolerations`                      | Tolerations configuration for the deployment                                             | `[]`                    |

--- a/pypiserver/templates/deployment.yaml
+++ b/pypiserver/templates/deployment.yaml
@@ -43,8 +43,6 @@ spec:
         {{- end }}
       containers:
         - name: {{ template "pypiserver.name" . }}
-          securityContext:
-            privileged: {{ .Values.securityContext.privileged }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: ["pypi-server"]

--- a/pypiserver/templates/deployment.yaml
+++ b/pypiserver/templates/deployment.yaml
@@ -35,12 +35,12 @@ spec:
         - name: {{ . }}
       {{- end }}
       {{- end }}
+      {{- if .Values.securityContext.enabled }}
       securityContext:
         runAsUser: {{ .Values.securityContext.runAsUser }}
         runAsGroup: {{ .Values.securityContext.runAsGroup }}
-        {{- if .Values.persistence.enabled }}
-        fsGroup: 1000
-        {{- end }}
+        fsGroup: {{ .Values.securityContext.fsGroup }}
+      {{- end }}
       containers:
         - name: {{ template "pypiserver.name" . }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/pypiserver/templates/deployment.yaml
+++ b/pypiserver/templates/deployment.yaml
@@ -35,12 +35,16 @@ spec:
         - name: {{ . }}
       {{- end }}
       {{- end }}
-      {{- if .Values.persistence.enabled }}
       securityContext:
+        runAsUser: {{ .Values.securityContext.runAsUser }}
+        runAsGroup: {{ .Values.securityContext.runAsGroup }}
+        {{- if .Values.persistence.enabled }}
         fsGroup: 1000
-      {{- end }}
+        {{- end }}
       containers:
         - name: {{ template "pypiserver.name" . }}
+          securityContext:
+            privileged: {{ .Values.securityContext.privileged }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: ["pypi-server"]
@@ -57,8 +61,14 @@ spec:
               containerPort: 8080
               protocol: TCP
           volumeMounts:
+            {{- if .Values.externalMount.enabled }}
+            - mountPath: /data/packages
+              name: externalmount
+              mountPropagation: HostToContainer
+            {{- else }}
             - mountPath: /data/packages
               name: packages
+            {{- end}}
             - mountPath: /config
               name: secrets
               readOnly: true
@@ -82,6 +92,12 @@ spec:
         - name: secrets
           secret:
             secretName: {{ template "pypiserver.fullname" . }}
+        {{- if .Values.externalMount.enabled }}
+        - name: externalmount
+          hostPath:
+            path: {{ .Values.externalMount.path }}
+            type: Directory
+        {{- end }}
         - name: packages
         {{- if .Values.persistence.enabled }}
           persistentVolumeClaim:

--- a/pypiserver/templates/deployment.yaml
+++ b/pypiserver/templates/deployment.yaml
@@ -61,9 +61,9 @@ spec:
               containerPort: 8080
               protocol: TCP
           volumeMounts:
-            {{- if .Values.externalMount.enabled }}
+            {{- if .Values.hostPathMount.enabled }}
             - mountPath: /data/packages
-              name: externalmount
+              name: hostpathmount
               mountPropagation: HostToContainer
             {{- else }}
             - mountPath: /data/packages
@@ -92,10 +92,10 @@ spec:
         - name: secrets
           secret:
             secretName: {{ template "pypiserver.fullname" . }}
-        {{- if .Values.externalMount.enabled }}
-        - name: externalmount
+        {{- if .Values.hostPathMount.enabled }}
+        - name: hostpathmount
           hostPath:
-            path: {{ .Values.externalMount.path }}
+            path: {{ .Values.hostPathMount.path }}
             type: Directory
         {{- end }}
         - name: packages

--- a/pypiserver/templates/deployment.yaml
+++ b/pypiserver/templates/deployment.yaml
@@ -59,14 +59,9 @@ spec:
               containerPort: 8080
               protocol: TCP
           volumeMounts:
-            {{- if .Values.hostPathMount.enabled }}
-            - mountPath: /data/packages
-              name: hostpathmount
-              mountPropagation: HostToContainer
-            {{- else }}
             - mountPath: /data/packages
               name: packages
-            {{- end}}
+              mountPropagation: {{ .Values.persistence.mountPropagation }}
             - mountPath: /config
               name: secrets
               readOnly: true
@@ -90,12 +85,6 @@ spec:
         - name: secrets
           secret:
             secretName: {{ template "pypiserver.fullname" . }}
-        {{- if .Values.hostPathMount.enabled }}
-        - name: hostpathmount
-          hostPath:
-            path: {{ .Values.hostPathMount.path }}
-            type: Directory
-        {{- end }}
         - name: packages
         {{- if .Values.persistence.enabled }}
           persistentVolumeClaim:

--- a/pypiserver/values.yaml
+++ b/pypiserver/values.yaml
@@ -71,7 +71,7 @@ persistence:
   accessMode: ReadWriteOnce
   size: 5Gi
 
-externalMount:
+hostPathMount:
   enabled: false
   # path: /
 

--- a/pypiserver/values.yaml
+++ b/pypiserver/values.yaml
@@ -73,7 +73,7 @@ persistence:
   mountPropagation: None
 
 securityContext:
-  enabled: false
+  enabled: true
   runAsUser: 0
   runAsGroup: 0
   fsGroup: 1000

--- a/pypiserver/values.yaml
+++ b/pypiserver/values.yaml
@@ -70,7 +70,7 @@ persistence:
   ## than one replica
   accessMode: ReadWriteOnce
   size: 5Gi
-  # mountPropagation: HostToContainer
+  mountPropagation: None
 
 securityContext:
   enabled: false

--- a/pypiserver/values.yaml
+++ b/pypiserver/values.yaml
@@ -76,8 +76,10 @@ hostPathMount:
   # path: /
 
 securityContext:
+  enabled: false
   runAsUser: 0
   runAsGroup: 0
+  fsGroup: 1000
 
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious

--- a/pypiserver/values.yaml
+++ b/pypiserver/values.yaml
@@ -78,7 +78,6 @@ hostPathMount:
 securityContext:
   runAsUser: 0
   runAsGroup: 0
-  privileged: false
 
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious

--- a/pypiserver/values.yaml
+++ b/pypiserver/values.yaml
@@ -71,6 +71,15 @@ persistence:
   accessMode: ReadWriteOnce
   size: 5Gi
 
+externalMount:
+  enabled: false
+  # path: /
+
+securityContext:
+  runAsUser: 0
+  runAsGroup: 0
+  privileged: false
+
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little

--- a/pypiserver/values.yaml
+++ b/pypiserver/values.yaml
@@ -70,10 +70,7 @@ persistence:
   ## than one replica
   accessMode: ReadWriteOnce
   size: 5Gi
-
-hostPathMount:
-  enabled: false
-  # path: /
+  # mountPropagation: HostToContainer
 
 securityContext:
   enabled: false


### PR DESCRIPTION
* Allow specifying runAsUser and runAsGroup
* Allow using an externally mounted directory for packages

**What this PR does / why we need it**:

In order to use this helm chart at our organisation we need to be able to configure these options. They allow us to mount an external filesystem to use for serving packages.

**Which issue(s) this PR fixes**:

None but I could open one if you like.

**Special notes for your reviewer**:

I am not experienced in using Kubernetes so I am happy to make any modifications that you suggest.

I have kept this as a 'draft' because we are still working on this, but I would like to see if you are open to accepting this contribution.

**Checklist**:
- [x] Bumped chart version in Chart.yaml
- [x] Added an entry in the CHANGELOG.md
- [ ] Added an entry in the UPGRADE.md if this pull request creates a backward compatibility breaking change
- [ ] Reference your chart in the build matrix of the .travis.yml (For new charts)
