### PR TITLE
[hlf-peer] Change couchdb value to make it explicit

### DIFF
--- a/hlf-peer/CHANGELOG.md
+++ b/hlf-peer/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [3.0.0]
+
+### Breaking changes
+- `couchdbSecret` replaces `couchdbInstance` to make the value explicit

--- a/hlf-peer/Chart.yaml
+++ b/hlf-peer/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Hyperledger Fabric Peer chart (these charts are forked from the one by AID:Tech and are currently not directly associated with them or Hyperledger project)
 name: hlf-peer
-version: 2.0.0
+version: 3.0.0
 appVersion: 2.2.1
 keywords:
   - blockchain

--- a/hlf-peer/README.md
+++ b/hlf-peer/README.md
@@ -101,7 +101,7 @@ The following table lists the configurable parameters of the Hyperledger Fabric 
 | `docker.config`                     | Docker Config file base 64 encoded                             | `null`                    |
 | `docker.configMountPath`            | Docker Config file mount path                                  | `/root/.docker`           |
 | `peer.databaseType`                 | Database type to use (`goleveldb` or `CouchDB`)                | `goleveldb`               |
-| `peer.couchdbInstance`              | CouchDB chart name to use `cdb-peer1`                          | `cdb-peer1`               |
+| `peer.couchdbSecret`                | Secret holding the couchdb credentials                         | `cdb-peer1-hlf-couchdb`   |
 | `peer.mspID`                        | ID of MSP the Peer belongs to                                  | `Org1MSP`                 |
 | `peer.gossip.bootstrap`             | Gossip bootstrap address                                       | ``                        |
 | `peer.gossip.endpoint`              | Gossip endpoint                                                | ``                        |

--- a/hlf-peer/templates/deployment.yaml
+++ b/hlf-peer/templates/deployment.yaml
@@ -169,7 +169,7 @@ spec:
           envFrom:
             {{- if eq .Values.peer.databaseType "CouchDB" }}
             - secretRef:
-                name: {{ .Values.peer.couchdbInstance }}-hlf-couchdb
+                name: {{ .Values.peer.couchdbSecret }}
             {{- end }}
             - configMapRef:
                 name: {{ include "hlf-peer.fullname" . }}--peer

--- a/hlf-peer/values.yaml
+++ b/hlf-peer/values.yaml
@@ -68,8 +68,8 @@ logging:
 peer:
   # Type of database ("goleveldb" or "CouchDB"):
   databaseType: goleveldb
-  # If CouchDB is used, which chart holds it
-  couchdbInstance: cdb-peer1
+  # If CouchDB is used the name of the secret holding couchdb credentials
+  couchdbSecret: cdb-peer1-hlf-couchdb
   ## MSP ID of the Peer
   mspID: Org1MSP
   gossip:


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR makes the value `couchdbInstance` clearer by renaming it to `couchdbSecret` and removing the hardcoded part (`-hlf-couchdb`) from the `deployment.yaml` template.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
N/A

**Special notes for your reviewer**:

**Checklist**:
- [x] Bumped chart version in Chart.yaml
- [x] Added an entry in the CHANGELOG.md
- [ ] Added an entry in the UPGRADE.md if this pull request creates a backward compatibility breaking change
- [ ] Reference your chart in the build matrix of the .travis.yml (For new charts)
