### PR TITLE
Fix issue with Ordering service start-up using Raft

### DIFF
--- a/hlf-ord/CHANGELOG.md
+++ b/hlf-ord/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [2.2.1]
+
+### Fixed
+- Fixes an issue with mutual TLS on Raft cluster after restart

--- a/hlf-ord/Chart.yaml
+++ b/hlf-ord/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Hyperledger Fabric Orderer chart (these charts are forked from the one by AID:Tech and are currently not directly associated with them or Hyperledger project)
 name: hlf-ord
-version: 2.0.0
+version: 2.0.1
 appVersion: 2.2.1
 keywords:
   - blockchain

--- a/hlf-ord/templates/configmap--ord.yaml
+++ b/hlf-ord/templates/configmap--ord.yaml
@@ -32,6 +32,9 @@ data:
   ORDERER_GENERAL_TLS_CLIENTROOTCAS: "/var/hyperledger/tls/client/cert/*"
   ORDERER_GENERAL_TLS_CLIENTCERT_FILE: "/var/hyperledger/tls/client/pair/tls.crt"
   ORDERER_GENERAL_TLS_CLIENTKEY_FILE: "/var/hyperledger/tls/client/pair/tls.key"
+  ORDERER_GENERAL_CLUSTER_CLIENTCERTIFICATE: "/var/hyperledger/tls/server/pair/tls.crt"
+  ORDERER_GENERAL_CLUSTER_CLIENTPRIVATEKEY: "/var/hyperledger/tls/server/pair/tls.key"
+  ORDERER_GENERAL_CLUSTER_ROOTCAS: "/var/hyperledger/tls/server/cert/cacert.pem"
   GODEBUG: "netdns=go"
   ADMIN_MSP_PATH: /var/hyperledger/admin_msp
   ##############


### PR DESCRIPTION
**What this PR does / why we need it**:
Raft cluster need some environment variables defined in order to work properly with mutual tls.
This PR fixes that.

Here is the trace from the orderer startup without the variable:
```
2020-12-29 11:29:29.621 UTC [orderer.common.server] initializeServerConfig -> INFO 004 Starting orderer with mutual TLS enabled
2020-12-29 11:29:29.662 UTC [orderer.common.server] Main -> INFO 005 Not bootstrapping the system channel because of existing channels
2020-12-29 11:29:29.687 UTC [orderer.common.server] selectClusterBootBlock -> INFO 006 Cluster boot block is system channel last config block; Blocks Header.Number system-channel=1, bootstrap=0
2020-12-29 11:29:29.691 UTC [orderer.common.server] Main -> INFO 007 Starting with system channel: systemchannel, consensus type: etcdraft
2020-12-29 11:29:29.691 UTC [orderer.common.server] Main -> INFO 008 Setting up cluster
2020-12-29 11:29:29.691 UTC [orderer.common.server] reuseListener -> INFO 009 Cluster listener is not configured, defaulting to use the general listener on port 7050
2020-12-29 11:29:29.695 UTC [orderer.common.cluster] loadVerifier -> INFO 00a Loaded verifier for channel healthchain-1 from config block at index 43648
2020-12-29 11:29:29.697 UTC [orderer.common.cluster] loadVerifier -> INFO 00b Loaded verifier for channel restricted-owkin from config block at index 43649
2020-12-29 11:29:29.699 UTC [orderer.common.cluster] loadVerifier -> INFO 00c Loaded verifier for channel systemchannel from config block at index 3
2020-12-29 11:29:29.701 UTC [orderer.common.cluster] createReplicator -> PANI 00d Failed creating puller config from bootstrap block: unable to decode TLS certificate PEM: 
panic: Failed creating puller config from bootstrap block: unable to decode TLS certificate PEM: 
goroutine 1 [running]:
go.uber.org/zap/zapcore.(*CheckedEntry).Write(0xc000247130, 0x0, 0x0, 0x0)
    /go/src/github.com/hyperledger/fabric/vendor/go.uber.org/zap/zapcore/entry.go:230 +0x545
go.uber.org/zap.(*SugaredLogger).log(0xc0006c4450, 0x4, 0x1038928, 0x36, 0xc00017b310, 0x1, 0x1, 0x0, 0x0, 0x0)
    /go/src/github.com/hyperledger/fabric/vendor/go.uber.org/zap/sugar.go:234 +0x100
go.uber.org/zap.(*SugaredLogger).Panicf(...)
    /go/src/github.com/hyperledger/fabric/vendor/go.uber.org/zap/sugar.go:159
github.com/hyperledger/fabric/common/flogging.(*FabricLogger).Panicf(...)
    /go/src/github.com/hyperledger/fabric/common/flogging/zap.go:74
github.com/hyperledger/fabric/orderer/common/onboarding.(*ReplicationInitiator).createReplicator(0xc0000e4500, 0xc000565280, 0x1056728, 0xc00017b4a0)
    /go/src/github.com/hyperledger/fabric/orderer/common/onboarding/onboarding.go:125 +0x33c
github.com/hyperledger/fabric/orderer/common/onboarding.(*ReplicationInitiator).replicateNeededChannels(0xc0000e4500, 0xc000565280)
    /go/src/github.com/hyperledger/fabric/orderer/common/onboarding/onboarding.go:154 +0x69
github.com/hyperledger/fabric/orderer/common/onboarding.(*ReplicationInitiator).ReplicateIfNeeded(0xc0000e4500, 0xc000565280)
    /go/src/github.com/hyperledger/fabric/orderer/common/onboarding/onboarding.go:108 +0x9a
github.com/hyperledger/fabric/orderer/common/server.Main()
    /go/src/github.com/hyperledger/fabric/orderer/common/server/main.go:188 +0x1814
main.main()
    /go/src/github.com/hyperledger/fabric/cmd/orderer/main.go:15 +0x20
```

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
I basically got the fix from [stackoverflow](https://stackoverflow.com/questions/56736465/how-to-fix-failed-creating-puller-config-from-bootstrap-block-unable-to-decode)

**Checklist**:
- [x] Bumped chart version in Chart.yaml
- [x] Added an entry in the CHANGELOG.md
- [x] Added an entry in the UPGRADE.md if this pull request creates a backward compatibility breaking change
- [x] Reference your chart in the build matrix of the .travis.yml (For new charts)
