### PR TITLE
[ci] fix charts publication

### DIFF
--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   test:
-    name: Lint
+    name: Build
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -26,41 +26,43 @@ jobs:
         with:
           version: 'v3.2.3'
         id: install
-      - name: Lint charts
+      - name: Configure Helm repo
+        run: helm repo add stable https://charts.helm.sh/stable
+      - name: Lint chart
         run: helm lint ${{ matrix.package }}
+      - name: Package chart
+        run: |
+          helm dep build ${{ matrix.package }}
+          helm package ${{ matrix.package }} -d dist
+      - name: Archive packaged chart
+        uses: actions/upload-artifact@v2
+        with:
+          name: dist-${{matrix.package}}
+          path: dist/*.tgz
   publish:
     name: Publish
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/master' && github.event_name == 'push'
     needs: test
-    strategy:
-      matrix:
-        package:
-          - pypiserver
-          - hlf-couchdb
-          - hlf-ca
-          - hlf-peer
-          - hlf-ord
     steps:
       - uses: actions/checkout@v2
       - uses: azure/setup-helm@v1
         with:
             version: 'v3.2.3'
         id: install
-      - name: Package chart
-        run: |
-          helm package ${{ matrix.package }}
+      - name: Download all workflow run artifacts
+        uses: actions/download-artifact@v2
       - name: Setup key
         run: |
           mkdir $HOME/.ssh
           echo "${{ secrets.CHARTS_ACCESS_KEY }}" > $HOME/.ssh/id_rsa
           chmod 400 ~/.ssh/id_rsa
-      - name: Publish chart
+      - name: Publish charts
         run: |
           git config --global user.email "gh-actions@github.com"
           git config --global user.name "GitHub Action"
-          git clone git@github.com:Owkin/charts.git charts -b gh-pages
-          mv ${{matrix.package}}-*.tgz charts/
+          git clone git@github.com:owkin/charts.git charts -b gh-pages
+          mv dist-*/*.tgz charts/
           cd charts
           helm repo index .
           git add .

--- a/hlf-ca/requirements.lock
+++ b/hlf-ca/requirements.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: postgresql
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  repository: https://charts.helm.sh/stable
   version: 2.6.1
 - name: mysql
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  repository: https://charts.helm.sh/stable
   version: 0.10.2
-digest: sha256:1b5b212945abc2abc2317189f0d048b1c90f093db8ed5482db2c35a9d463259f
-generated: 2018-11-16T17:00:11.413931+02:00
+digest: sha256:b3c60838d65e79bebcbe9a97cb064763efcca65f9eeda6b523591f4f0f16bd70
+generated: "2021-01-13T14:44:55.081453+01:00"

--- a/hlf-ca/requirements.yaml
+++ b/hlf-ca/requirements.yaml
@@ -1,14 +1,14 @@
 dependencies:
 - name: postgresql
-  version: x.x.x
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  version: 2.6.1
+  repository: https://charts.helm.sh/stable
   condition: postgresql.enabled
   tags:
     - postgres-database
 
 - name: mysql
-  version: x.x.x
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  version: 0.10.2
+  repository: https://charts.helm.sh/stable
   condition: mysql.enabled
   tags:
     - mysql-database


### PR DESCRIPTION
**What this PR does / why we need it**:
<!--  Thanks for sending a pull request! Please add at least a small note here to explain what the change does: -->

This fixes chart publication through github actions.
Now packages are built in parallel but publication happen only once.

I had to update the repository of hlf-ca dependencies since that was the deprecated https://kubernetes-charts.storage.googleapis.com/ repo.