### PR TITLE
[all]: Add namespace option to kubectl commands where it is missing

### DIFF
--- a/hlf-ca/templates/NOTES.txt
+++ b/hlf-ca/templates/NOTES.txt
@@ -18,14 +18,14 @@ Run the following commands to...
   echo http://$SERVICE_IP:{{ .Values.service.port }}
 {{- else if contains "ClusterIP" .Values.service.type }}
   echo "Visit http://127.0.0.1:8080 to use your application"
-  kubectl port-forward $POD_NAME 8080:7054
+  kubectl port-forward --namespace {{ .Release.Namespace }} $POD_NAME 8080:7054
 {{- end }}
 
 3. Display local (admin "client" enrollment) certificate, if it has been created:
-  kubectl exec $POD_NAME -- cat /var/hyperledger/fabric-ca/msp/signcerts/cert.pem
+  kubectl exec --namespace {{ .Release.Namespace }} $POD_NAME -- cat /var/hyperledger/fabric-ca/msp/signcerts/cert.pem
 
 4. Enroll the bootstrap admin identity:
-  kubectl exec $POD_NAME -- bash -c 'fabric-ca-client enroll -d -u http://$CA_ADMIN:$CA_PASSWORD@$SERVICE_DNS:{{ .Values.service.port }}'
+  kubectl exec --namespace {{ .Release.Namespace }} $POD_NAME -- bash -c 'fabric-ca-client enroll -d -u http://$CA_ADMIN:$CA_PASSWORD@$SERVICE_DNS:{{ .Values.service.port }}'
 
 5. Update the chart without resetting a password:
   export CA_ADMIN=$(kubectl get secret --namespace {{ .Release.Namespace }} {{ include "hlf-ca.fullname" . }}--ca -o jsonpath="{.data.CA_ADMIN}" | base64 --decode; echo)

--- a/hlf-couchdb/templates/NOTES.txt
+++ b/hlf-couchdb/templates/NOTES.txt
@@ -15,7 +15,7 @@
 {{- else if contains "ClusterIP" .Values.service.type }}
   export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ include "hlf-couchdb.name" . }},release={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
   echo "Visit http://127.0.0.1:8080 to use your application"
-  kubectl port-forward $POD_NAME 8080:80
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:80
 {{- end }}
 
 2. Get the CouchDB username and password by running this command:

--- a/hlf-ord/templates/NOTES.txt
+++ b/hlf-ord/templates/NOTES.txt
@@ -15,7 +15,7 @@ Run the following commands to...
 {{- else if contains "ClusterIP" .Values.service.type }}
   export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ include "hlf-ord.name" . }},release={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
   echo "Visit http://127.0.0.1:8080 to use your application"
-  kubectl port-forward $POD_NAME 8080:7050
+  kubectl port-forward --namespace {{ .Release.Namespace }} $POD_NAME 8080:7050
 {{- end }}
 
 3. Obtain CA_USERNAME and CA_PASSWORD to register identity with CA:

--- a/hlf-peer/templates/NOTES.txt
+++ b/hlf-peer/templates/NOTES.txt
@@ -15,7 +15,7 @@ Run the following commands to...
 {{- else if contains "ClusterIP" .Values.service.type }}
   export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ include "hlf-peer.name" . }},release={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
   echo "Visit http://127.0.0.1:8080 to use your application"
-  kubectl port-forward $POD_NAME 8080:7051
+  kubectl port-forward --namespace {{ .Release.Namespace }} $POD_NAME 8080:7051
 {{- end }}
 
 3. Obtain CA_USERNAME and CA_PASSWORD to register identity with CA:

--- a/pypiserver/templates/NOTES.txt
+++ b/pypiserver/templates/NOTES.txt
@@ -15,5 +15,5 @@
 {{- else if contains "ClusterIP" .Values.service.type }}
   export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ template "pypiserver.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
   echo "Visit http://127.0.0.1:8080 to use your application"
-  kubectl port-forward $POD_NAME 8080:{{ .Values.service.port }}
+  kubectl port-forward --namespace {{ .Release.Namespace }} $POD_NAME 8080:{{ .Values.service.port }}
 {{- end }}


### PR DESCRIPTION
**What this PR does / why we need it**:
<!--  Thanks for sending a pull request! Please add at least a small note here to explain what the change does: -->

Some commands in NOTES.txt were missing the namespace option. This PR adds the `--namespace` option on all those places and increases the copy-paste UX.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

**Special notes for your reviewer**:

Do I need to bump the chart version and add a CHANGELOG entry in all charts? I am asking since it is just a documentation change.

**Checklist**:
- [ ] Bumped chart version in Chart.yaml
- [ ] Added an entry in the CHANGELOG.md
- [X] Added an entry in the UPGRADE.md if this pull request creates a backward compatibility breaking change
- [X] Reference your chart in the build matrix of the .travis.yml (For new charts)
