### PR TITLE
[hlf-peer] feat: Add pullImageSecret to be able to fetch image from a private registry

### DIFF
--- a/hlf-peer/CHANGELOG.md
+++ b/hlf-peer/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.1.0]
+
+### Added
+- `pullImageSecret` is added to be able to pull image from a private registry
+
 ## [3.0.0]
 
 ### Breaking changes

--- a/hlf-peer/Chart.yaml
+++ b/hlf-peer/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Hyperledger Fabric Peer chart (these charts are forked from the one by AID:Tech and are currently not directly associated with them or Hyperledger project)
 name: hlf-peer
-version: 3.0.0
+version: 3.1.0
 appVersion: 2.2.1
 keywords:
   - blockchain

--- a/hlf-peer/README.md
+++ b/hlf-peer/README.md
@@ -76,6 +76,7 @@ The following table lists the configurable parameters of the Hyperledger Fabric 
 | `image.repository`                  | `hlf-peer` image repository                                    | `hyperledger/fabric-peer` |
 | `image.tag`                         | `hlf-peer` image tag                                           | `1.4.3`                   |
 | `image.pullPolicy`                  | Image pull policy                                              | `IfNotPresent`            |
+| `image.pullImageSecret`             | Image pull secret name                                         |  `nil`                    |
 | `service.portRequest`               | TCP port for requests to Peer                                  | `7051`                    |
 | `service.portEvent`                 | TCP port for event service on Peer                             | `7053`                    |
 | `service.portMetrics`               | TCP port for the metrics service on Peer                       | `9443`                    |

--- a/hlf-peer/templates/deployment.yaml
+++ b/hlf-peer/templates/deployment.yaml
@@ -19,6 +19,10 @@ spec:
       labels:
 {{ include "labels.standard" . | indent 8 }}
     spec:
+      {{- if .Values.image.pullImageSecret }}
+      imagePullSecrets:
+        - name: {{ .Values.image.pullImageSecret }}
+      {{- end }}
       volumes:
         - name: data
         {{- if .Values.persistence.enabled }}

--- a/hlf-peer/values.yaml
+++ b/hlf-peer/values.yaml
@@ -6,6 +6,7 @@ image:
   repository: hyperledger/fabric-peer
   tag: 2.2.1
   pullPolicy: IfNotPresent
+  # pullImageSecret: docker-config
 
 service:
   # Cluster IP or LoadBalancer


### PR DESCRIPTION
Add pullImageSecret to be able to fetch image from a private registry

**What this PR does / why we need it**:
<!--  Thanks for sending a pull request! Please add at least a small note here to explain what the change does: -->
This PR allows user to be able to specify a private image for hlf-peer deployment.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
None

**Special notes for your reviewer**:

**Checklist**:
- [x] Bumped chart version in Chart.yaml
- [x] Added an entry in the CHANGELOG.md
- [ ] Added an entry in the UPGRADE.md if this pull request creates a backward compatibility breaking change
- [ ] Reference your chart in the build matrix of the .travis.yml (For new charts)
