### PR TITLE
[hlf-peer] fix: missing couchdbInstance value for peer connection

### DIFF
--- a/hlf-peer/CHANGELOG.md
+++ b/hlf-peer/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.2.0]
+
+### Added
+- `couchdbInstance` is necessary for the connection with the peer
+
 ## [3.1.0]
 
 ### Added

--- a/hlf-peer/Chart.yaml
+++ b/hlf-peer/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Hyperledger Fabric Peer chart (these charts are forked from the one by AID:Tech and are currently not directly associated with them or Hyperledger project)
 name: hlf-peer
-version: 3.1.0
+version: 3.2.0
 appVersion: 2.2.1
 keywords:
   - blockchain

--- a/hlf-peer/README.md
+++ b/hlf-peer/README.md
@@ -103,6 +103,7 @@ The following table lists the configurable parameters of the Hyperledger Fabric 
 | `docker.configMountPath`            | Docker Config file mount path                                  | `/root/.docker`           |
 | `peer.databaseType`                 | Database type to use (`goleveldb` or `CouchDB`)                | `goleveldb`               |
 | `peer.couchdbSecret`                | Secret holding the couchdb credentials                         | `cdb-peer1-hlf-couchdb`   |
+| `peer.couchdbInstance`              | CouchDB chart name to use                                      | `cdb-peer1`               |
 | `peer.mspID`                        | ID of MSP the Peer belongs to                                  | `Org1MSP`                 |
 | `peer.gossip.bootstrap`             | Gossip bootstrap address                                       | ``                        |
 | `peer.gossip.endpoint`              | Gossip endpoint                                                | ``                        |

--- a/hlf-peer/values.yaml
+++ b/hlf-peer/values.yaml
@@ -71,6 +71,7 @@ peer:
   databaseType: goleveldb
   # If CouchDB is used the name of the secret holding couchdb credentials
   couchdbSecret: cdb-peer1-hlf-couchdb
+  couchdbInstance: cdb-peer1
   ## MSP ID of the Peer
   mspID: Org1MSP
   gossip:


### PR DESCRIPTION
**What this PR does / why we need it**:
<!--  Thanks for sending a pull request! Please add at least a small note here to explain what the change does: -->
Fix missing couchdbInstance value for peer connection which has been removed after 3.0.0
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
None

**Special notes for your reviewer**:

**Checklist**:
- [x] Bumped chart version in Chart.yaml
- [x] Added an entry in the CHANGELOG.md
- [ ] Added an entry in the UPGRADE.md if this pull request creates a backward compatibility breaking change
- [ ] Reference your chart in the build matrix of the .travis.yml (For new charts)
