### PR TITLE
[hlf-couchdb] switch to upstream couchdb image

### DIFF
--- a/hlf-couchdb/Chart.yaml
+++ b/hlf-couchdb/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: CouchDB instance for Hyperledger Fabric (these charts are forked from the one by AID:Tech and are currently not directly associated with them or Hyperledger project)
 name: hlf-couchdb
-version: 1.0.7
-appVersion: 0.4.10
+version: 1.1.0
+appVersion: 3.1.1
 keywords:
   - blockchain
   - hyperledger

--- a/hlf-couchdb/templates/secret.yaml
+++ b/hlf-couchdb/templates/secret.yaml
@@ -6,7 +6,7 @@ metadata:
 {{ include "labels.standard" . | indent 4 }}
 type: Opaque
 data:
-  COUCHDB_USERNAME:  {{ .Values.couchdbUsername | b64enc | quote }}
+  COUCHDB_USER:  {{ .Values.couchdbUsername | b64enc | quote }}
   {{ if .Values.couchdbPassword }}
   COUCHDB_PASSWORD:  {{ .Values.couchdbPassword | b64enc | quote }}
   {{ else }}

--- a/hlf-couchdb/values.yaml
+++ b/hlf-couchdb/values.yaml
@@ -5,8 +5,8 @@
 replicaCount: 1
 
 image:
-  repository: hyperledger/fabric-couchdb
-  tag: 0.4.10
+  repository: couchdb
+  tag: 3.1.1
   pullPolicy: IfNotPresent
 
 service:


### PR DESCRIPTION
**What this PR does / why we need it**:
<!--  Thanks for sending a pull request! Please add at least a small note here to explain what the change does: -->
Base images are deprecated (see https://github.com/hyperledger/fabric-baseimage),
and it is now advised to rely on official upstream images.
This commit bumps the chart and update couchdb image to the official one
in version 3.1.1. It also change the env var used to define couchdb user
as without it authentication was completely disabled (anonymous admin).

I successfully tested this version on local dev.

**Special notes for your reviewer**:

**Checklist**:
- [x] Bumped chart version in Chart.yaml
- [ ] Added an entry in the CHANGELOG.md
- [ ] Added an entry in the UPGRADE.md if this pull request creates a backward compatibility breaking change
- [ ] Reference your chart in the build matrix of the .travis.yml (For new charts)
