### PR TITLE
feat(hlf-couchdb)!: Kubernetes 1.22 support

### DIFF
--- a/hlf-couchdb/CHANGELOG.md
+++ b/hlf-couchdb/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [2.0.0] - 2021-09-06
+
+### Added
+- Support for Kubernetes 1.22.0
+- Support for Helm APIVersion v2
+
+### Removed
+- Support for Kubernetes <=1.19.0

--- a/hlf-couchdb/Chart.yaml
+++ b/hlf-couchdb/Chart.yaml
@@ -1,8 +1,9 @@
-apiVersion: v1
-description: CouchDB instance for Hyperledger Fabric (these charts are forked from the one by AID:Tech and are currently not directly associated with them or Hyperledger project)
+apiVersion: v2
 name: hlf-couchdb
-version: 1.1.0
-appVersion: 3.1.1
+version: 2.0.0
+kubeVersion: ">= 1.19.0"
+description: CouchDB instance for Hyperledger Fabric (these charts are forked from the one by AID:Tech and are currently not directly associated with them or Hyperledger project)
+type: application
 keywords:
   - blockchain
   - hyperledger
@@ -21,3 +22,4 @@ maintainers:
   - name: Kelvin-M
     email: kelvin.moutet@owkin.com
 icon: https://www.hyperledger.org/wp-content/uploads/2018/04/fabric-logo.png
+appVersion: 3.1.1

--- a/hlf-couchdb/README.md
+++ b/hlf-couchdb/README.md
@@ -66,7 +66,7 @@ The command removes all the Kubernetes components associated with the chart and 
 
 The following table lists the configurable parameters of the Hyperledger Fabric CouchDB chart and default values.
 
-| Parameter                          | Description                                     | Default                                                    |
+| Parameter                          | Description                                      | Default                                                    |
 | ---------------------------------- | ------------------------------------------------ | ---------------------------------------------------------- |
 | `image.repository`                 | `hlf-couchdb` image repository                   | `hyperledger/fabric-couchdb`                               |
 | `image.tag`                        | `hlf-couchdb` image tag                          | `x86_64-0.4.7`                                             |
@@ -77,12 +77,15 @@ The following table lists the configurable parameters of the Hyperledger Fabric 
 | `persistence.annotations`          | Persistent Volume annotations                    | `{}`                                                       |
 | `persistence.size`                 | Size of data volume (adjust for production!)     | `1Gi`                                                      |
 | `persistence.storageClass`         | Storage class of backing PVC                     | `default`                                                  |
-| `couchdbUsername`                  | Username for CouchDB                             | `couchdb`                                                     |
+| `couchdbUsername`                  | Username for CouchDB                             | `couchdb`                                                  |
 | `couchdbPassword`                  | Password for CouchDB                             | Random 24 alphanumeric characters                          |
 | `resources`                        | CPU/Memory resource requests/limits              | `{}`                                                       |
 | `nodeSelector`                     | Node labels for pod assignment                   | `{}`                                                       |
 | `tolerations`                      | Toleration labels for pod assignment             | `[]`                                                       |
 | `affinity`                         | Affinity settings for pod assignment             | `{}`                                                       |
+| `ingress.enabled`                  | If true, Ingress will be created                 | `false`                                                    |
+| `ingress.ingressClassName`         | Ingress class that will be used for the ingress  | `nil`                                                      |
+| `ingress.pathType`                 | Ingress path type                                | `ImplementationSpecific`                                   |
 
 ## Persistence
 

--- a/hlf-couchdb/templates/ingress.yaml
+++ b/hlf-couchdb/templates/ingress.yaml
@@ -1,10 +1,8 @@
 {{- if .Values.ingress.enabled -}}
-{{- $fullName := include "hlf-couchdb.fullname" . -}}
-{{- $ingressPath := .Values.ingress.path -}}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: {{ $fullName }}
+  name: {{ include "hlf-couchdb.fullname" . }}
   labels:
 {{ include "labels.standard" . | indent 4 }}
 {{- with .Values.ingress.annotations }}
@@ -12,24 +10,30 @@ metadata:
 {{ toYaml . | indent 4 }}
 {{- end }}
 spec:
-{{- if .Values.ingress.tls }}
-  tls:
-  {{- range .Values.ingress.tls }}
-    - hosts:
-      {{- range .hosts }}
-        - {{ . }}
-      {{- end }}
-      secretName: {{ .secretName }}
+  {{- if .Values.ingress.ingressCalssName }}
+  ingressClassName: {{ .Values.ingress.ingressClassName | quote }}
   {{- end }}
-{{- end }}
   rules:
-  {{- range .Values.ingress.hosts }}
+    {{- range .Values.ingress.hosts }}
     - host: {{ . }}
       http:
         paths:
-          - path: {{ $ingressPath }}
+          - path: {{ $.Values.ingress.path }}
+            pathType: {{ $.Values.ingress.pathType }}
             backend:
-              serviceName: {{ $fullName }}
-              servicePort: couchdb
+              service:
+                name: {{ include "hlf-couchdb.fullname" $ }}
+                port:
+                  name: couchdb
+    {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . }}
+        {{- end }}
+      secretName: {{ .secretName }}
+      {{- end }}
   {{- end }}
 {{- end }}

--- a/hlf-couchdb/values.yaml
+++ b/hlf-couchdb/values.yaml
@@ -15,10 +15,12 @@ service:
 
 ingress:
   enabled: false
+  ingressClassName:
   annotations: {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
   path: /
+  pathType: ImplementationSpecific
   hosts:
     - chart-example.local
   tls: []


### PR DESCRIPTION
**What this PR does / why we need it**:
<!--  Thanks for sending a pull request! Please add at least a small note here to explain what the change does: -->

This PR adds support for Kubernetes 1.22.

**Special notes for your reviewer**:

**Checklist**:
- [x] Bumped chart version in Chart.yaml
- [x] Added an entry in the CHANGELOG.md
- [ ] Added an entry in the UPGRADE.md if this pull request creates a backward compatibility breaking change
- [ ] Reference your chart in the build matrix of the .travis.yml (For new charts)
