### PR TITLE
feat(hlf-ord)!: Kubernetes 1.22 support

### DIFF
--- a/hlf-ord/CHANGELOG.md
+++ b/hlf-ord/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.0.0] - 2021-09-06
+
+### Added
+- Support for Kubernetes 1.22.0
+- Support for Helm APIVersion v2
+
+### Removed
+- Support for Kubernetes <=1.19.0
+
 ## [2.2.1]
 
 ### Fixed

--- a/hlf-ord/Chart.yaml
+++ b/hlf-ord/Chart.yaml
@@ -1,8 +1,9 @@
-apiVersion: v1
-description: Hyperledger Fabric Orderer chart (these charts are forked from the one by AID:Tech and are currently not directly associated with them or Hyperledger project)
+apiVersion: v2
 name: hlf-ord
-version: 2.0.1
-appVersion: 2.2.1
+version: 3.0.0
+kubeVersion: ">= 1.19.0"
+description: Hyperledger Fabric Orderer chart (these charts are forked from the one by AID:Tech and are currently not directly associated with them or Hyperledger project)
+type: application
 keywords:
   - blockchain
   - hyperledger
@@ -20,3 +21,4 @@ maintainers:
   - name: Kelvin-M
     email: kelvin.moutet@owkin.com
 icon: https://www.hyperledger.org/wp-content/uploads/2018/04/fabric-logo.png
+appVersion: 2.2.1

--- a/hlf-ord/README.md
+++ b/hlf-ord/README.md
@@ -95,6 +95,8 @@ The following table lists the configurable parameters of the Hyperledger Fabric 
 | `service.portMetrics`              | TCP port for the metrics service                              | `9443`                                                     |
 | `ingress.enabled`                  | If true, Ingress will be created                              | `false`                                                    |
 | `ingress.annotations`              | Ingress annotations                                           | `{}`                                                       |
+| `ingress.ingressClassName`         | Ingress class that will be used for the ingress               | `nil`                                                      |
+| `ingress.pathType`                 | Ingress path type                                             | `ImplementationSpecific`                                   |
 | `ingress.path`                     | Ingress path                                                  | `/`                                                        |
 | `ingress.hosts`                    | Ingress hostnames                                             | `[]`                                                       |
 | `ingress.tls`                      | Ingress TLS configuration                                     | `[]`                                                       |

--- a/hlf-ord/templates/ingress.yaml
+++ b/hlf-ord/templates/ingress.yaml
@@ -1,10 +1,8 @@
 {{- if .Values.ingress.enabled -}}
-{{- $fullName := include "hlf-ord.fullname" . -}}
-{{- $ingressPath := .Values.ingress.path -}}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: {{ $fullName }}
+  name: {{ include "hlf-ord.fullname" . }}
   labels:
 {{ include "labels.standard" . | indent 4 }}
 {{- with .Values.ingress.annotations }}
@@ -12,24 +10,30 @@ metadata:
 {{ toYaml . | indent 4 }}
 {{- end }}
 spec:
-{{- if .Values.ingress.tls }}
-  tls:
-  {{- range .Values.ingress.tls }}
-    - hosts:
-      {{- range .hosts }}
-        - {{ . }}
-      {{- end }}
-      secretName: {{ .secretName }}
+  {{- if .Values.ingress.ingressClassName }}
+  ingressClassName: {{ .Values.ingress.ingressClassName | quote }}
   {{- end }}
-{{- end }}
   rules:
-  {{- range .Values.ingress.hosts }}
+    {{- range .Values.ingress.hosts }}
     - host: {{ . }}
       http:
         paths:
-          - path: {{ $ingressPath }}
+          - path: {{ $.Values.ingress.path }}
+            pathType: {{ $.Values.ingress.pathType }}
             backend:
-              serviceName: {{ $fullName }}
-              servicePort: grpc
+              service:
+                name: {{ include "hlf-ord.fullname" $ }}
+                port:
+                  name: grpc
+    {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . }}
+        {{- end }}
+      secretName: {{ .secretName }}
+      {{- end }}
   {{- end }}
 {{- end }}

--- a/hlf-ord/values.yaml
+++ b/hlf-ord/values.yaml
@@ -15,12 +15,14 @@ service:
 
 ingress:
   enabled: false
+  ingressClassName:
   annotations: {}
     # kubernetes.io/ingress.class: nginx
     # nginx.ingress.kubernetes.io/ssl-redirect: "true"
     # nginx.ingress.kubernetes.io/backend-protocol: "GRPC"
     # certmanager.k8s.io/cluster-issuer: "letsencrypt-staging"
   path: /
+  pathType: ImplementationSpecific
   hosts:
     - hlf-ord.local
   tls: []


### PR DESCRIPTION
**What this PR does / why we need it**:
<!--  Thanks for sending a pull request! Please add at least a small note here to explain what the change does: -->

This PR adds support for Kubernetes 1.22 and helm api v2.

**Special notes for your reviewer**:

**Checklist**:
- [x] Bumped chart version in Chart.yaml
- [x] Added an entry in the CHANGELOG.md
- [ ] Added an entry in the UPGRADE.md if this pull request creates a backward compatibility breaking change
- [ ] Reference your chart in the build matrix of the .travis.yml (For new charts)
