### PR TITLE
fix(hlf-xxx): add support for kubernetes 1.19 pre-releases

### DIFF
--- a/hlf-ca/CHANGELOG.md
+++ b/hlf-ca/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.1] - 2021-09-09
+
+### Added
+- Support for 1.19.x pre-releases
+
 ## [2.0.0] - 2021-09-03
 
 ### Added

--- a/hlf-ca/Chart.yaml
+++ b/hlf-ca/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: hlf-ca
-version: 2.0.0
-kubeVersion: ">= 1.19.0"
+version: 2.0.1
+kubeVersion: ">= 1.19.0-0"
 description: Hyperledger Fabric Certificate Authority chart (these charts are forked from the one by AID:Tech and are currently not directly associated with them or Hyperledger project)
 type: application
 keywords:

--- a/hlf-couchdb/CHANGELOG.md
+++ b/hlf-couchdb/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.1] - 2021-09-09
+
+### Added
+- Support for 1.19.x pre-releases
+
 ## [2.0.0] - 2021-09-06
 
 ### Added

--- a/hlf-couchdb/Chart.yaml
+++ b/hlf-couchdb/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: hlf-couchdb
-version: 2.0.0
-kubeVersion: ">= 1.19.0"
+version: 2.0.1
+kubeVersion: ">= 1.19.0-0"
 description: CouchDB instance for Hyperledger Fabric (these charts are forked from the one by AID:Tech and are currently not directly associated with them or Hyperledger project)
 type: application
 keywords:

--- a/hlf-ord/CHANGELOG.md
+++ b/hlf-ord/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+## [3.0.1] - 2021-09-09
+
+### Added
+- Support for 1.19.x pre-releases
+
 ## [3.0.0] - 2021-09-06
 
 ### Added

--- a/hlf-ord/Chart.yaml
+++ b/hlf-ord/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: hlf-ord
-version: 3.0.0
-kubeVersion: ">= 1.19.0"
+version: 3.0.1
+kubeVersion: ">= 1.19.0-0"
 description: Hyperledger Fabric Orderer chart (these charts are forked from the one by AID:Tech and are currently not directly associated with them or Hyperledger project)
 type: application
 keywords:

--- a/hlf-peer/CHANGELOG.md
+++ b/hlf-peer/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.0.1] - 2021-09-09
+
+### Added
+- Support for 1.19.x pre-releases
+
 ## [4.0.0] - 2021-09-06
 
 ### Added

--- a/hlf-peer/Chart.yaml
+++ b/hlf-peer/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: hlf-peer
-version: 4.0.0
-kubeVersion: ">= 1.19.0"
+version: 4.0.1
+kubeVersion: ">= 1.19.0-0"
 description: Hyperledger Fabric Peer chart (these charts are forked from the one by AID:Tech and are currently not directly associated with them or Hyperledger project)
 type: application
 keywords:


### PR DESCRIPTION
**What this PR does / why we need it**:
<!--  Thanks for sending a pull request! Please add at least a small note here to explain what the change does: -->

We need this PR because Google doesn't do semver properly for their Kubernetes releases (see https://github.com/helm/helm/issues/3810)

**Special notes for your reviewer**:

**Checklist**:
- [x] Bumped chart version in Chart.yaml
- [x] Added an entry in the CHANGELOG.md
- [ ] Added an entry in the UPGRADE.md if this pull request creates a backward compatibility breaking change
- [ ] Reference your chart in the build matrix of the .travis.yml (For new charts)
