### PR TITLE
feat(pypiserver)!: Kubernetes 1.22 support

### DIFF
--- a/pypiserver/CHANGELOG.md
+++ b/pypiserver/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.0.0]
+
+### Added
+- Support for Kubernetes 1.22
+- New value `ingress.pathType` to control how the ingress path should be interpreted by the underlying load balancer.
+- New value `ingress.ingressClassName` that replaces the old ingress annotation used to select the ingressClass.
+
+### Removed
+- Support for Kubernetes versions prior to 1.19
+
+### Changed
+- Helm api version
 ## [2.2.1]
 
 ### Fixed

--- a/pypiserver/Chart.yaml
+++ b/pypiserver/Chart.yaml
@@ -1,10 +1,10 @@
-apiVersion: v1
+apiVersion: v2
 name: pypiserver
-home: https://github.com/pypiserver/pypiserver
-version: 2.2.1
-appVersion: 1.3.2
+version: 3.0.0
+kubeVersion: ">= 1.19.0-0"
 description: PyPI compatible server for pip or easy_install.
-icon: https://raw.githubusercontent.com/pypiserver/pypiserver/master/pypiserver_logo.png
+type: application
+home: https://github.com/pypiserver/pypiserver
 sources:
   - https://github.com/owkin/charts/tree/master/pypiserver
   - https://github.com/pypiserver/pypiserver
@@ -12,3 +12,5 @@ sources:
 maintainers:
   - name: ClementGautier
     email: clement@gautier.im
+icon: https://raw.githubusercontent.com/pypiserver/pypiserver/master/pypiserver_logo.png
+appVersion: 1.3.2

--- a/pypiserver/README.md
+++ b/pypiserver/README.md
@@ -51,9 +51,11 @@ The following tables lists the configurable parameters of the PyPI server chart 
 | `auth.actions`                     | Actions requiring authentication (comma separated list)                                  | `update`                |
 | `auth.credentials`                 | Map of username / encoded password to write in a htpasswd file                           | `{}`                    |
 | `ingress.enabled`                  | Ingress configuration flag                                                               | `false`                 |
+| `ingress.ingressClassName`         | Ingress class name                                                                       | `nil`                   |
 | `ingress.labels`                   | Ingress labels                                                                           | `{}`                    |
 | `ingress.annotations`              | Ingress annotations                                                                      | `{}`                    |
 | `ingress.path`                     | Ingress path                                                                             | `nil`                   |
+| `ingress.pathType`                 | Ingress path type                                                                        | `ImplementationSpecific`|
 | `ingress.hosts`                    | Ingress hosts                                                                            | `nil`                   |
 | `ingress.tls`                      | Ingress TLS configuration                                                                | `[]`                    |
 | `service.type`                     | Service type                                                                             | `ClusterIP`             |
@@ -71,7 +73,7 @@ The following tables lists the configurable parameters of the PyPI server chart 
 | `persistence.accessMode`           | Persistence access mode                                                                  | `ReadWriteOnce`         |
 | `persistence.size`                 | Persistence volume size                                                                  | `5Gi`                   |
 | `persistence.mountPropagation`     | Mount propagation method                                                                 | `nil`                   |
-| `securityContext.enabled`          | Security context configuration flag                                                      | `true`                     |
+| `securityContext.enabled`          | Security context configuration flag                                                      | `true`                  |
 | `securityContext.runAsUser`        | User ID to run as                                                                        | `0`                     |
 | `securityContext.runAsGroup`       | Group ID to run as                                                                       | `0`                     |
 | `securityContext.fsGroup`          | Filesystem volume owner                                                                  | `1000`                  |

--- a/pypiserver/templates/_helpers.tpl
+++ b/pypiserver/templates/_helpers.tpl
@@ -14,3 +14,24 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- $name := default .Chart.Name .Values.nameOverride -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+
+{{/*
+Generate ingress backend entry that is compatible with all ports types.
+Usage:
+{{ include "pypiserver.ingress.backend" (dict "serviceName" "backendName" "servicePort" "backendPort") }}
+
+Params:
+  - serviceName - String. Name of an existing service backend
+  - servicePort - String/Int. Port name (or number) of the service. It will be translated to different yaml depending if it is a string or an integer.
+*/}}
+{{- define "pypiserver.ingress.backend" -}}
+service:
+  name: {{ .serviceName }}
+  port:
+    {{- if typeIs "string" .servicePort }}
+    name: {{ .servicePort }}
+    {{- else if or (typeIs "int" .servicePort) (typeIs "float64" .servicePort) }}
+    number: {{ .servicePort | int }}
+    {{- end }}
+{{- end -}}

--- a/pypiserver/templates/ingress.yaml
+++ b/pypiserver/templates/ingress.yaml
@@ -1,11 +1,8 @@
 {{- if .Values.ingress.enabled -}}
-{{- $fullName := include "pypiserver.fullname" . -}}
-{{- $servicePort := .Values.service.port -}}
-{{- $ingressPath := .Values.ingress.path -}}
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: {{ $fullName }}
+  name: {{ include "pypiserver.fullname" . }}
   labels:
     app.kubernetes.io/name: {{ template "pypiserver.name" . }}
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
@@ -16,24 +13,26 @@ metadata:
 {{ toYaml . | indent 4 }}
 {{- end }}
 spec:
-{{- if .Values.ingress.tls }}
-  tls:
-  {{- range .Values.ingress.tls }}
-    - hosts:
-      {{- range .hosts }}
-        - {{ . }}
-      {{- end }}
-      secretName: {{ .secretName }}
+  {{- if .Values.ingress.ingressClassName }}
+  ingressClassName: {{ .Values.ingress.ingressClassName | quote }}
   {{- end }}
-{{- end }}
   rules:
-  {{- range .Values.ingress.hosts }}
+    {{- range .Values.ingress.hosts }}
     - host: {{ . }}
       http:
         paths:
-          - path: {{ $ingressPath }}
-            backend:
-              serviceName: {{ $fullName }}
-              servicePort: {{ $servicePort }}
+          - path: {{ $.Values.ingress.path }}
+            pathType: {{ $.Values.ingress.pathType }}
+            backend: {{- include "pypiserver.ingress.backend" (dict "serviceName" (include "pypiserver.fullname" $) "servicePort" $.Values.service.port) | nindent 14 }}
+    {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . }}
+        {{- end }}
+      secretName: {{ .secretName }}
+      {{- end }}
   {{- end }}
 {{- end }}

--- a/pypiserver/values.yaml
+++ b/pypiserver/values.yaml
@@ -28,11 +28,15 @@ podLabels: {}
 
 ingress:
   enabled: false
+  ingressClassName:
   labels: {}
   annotations: {}
+  # hosts:
+  #   - pypiserver.org
   # kubernetes.io/ingress.class: nginx
   # kubernetes.io/tls-acme: "true"
   # path: "/pypiserver"
+  pathType: ImplementationSpecific
   tls: []
   # - secretName: pypiserver.cluster.local
   #   hosts:


### PR DESCRIPTION
**What this PR does / why we need it**:
<!--  Thanks for sending a pull request! Please add at least a small note here to explain what the change does: -->

This PR adds support for Kubernetes 1.22 and support for helm apiVersion v2.

**Special notes for your reviewer**:

**Checklist**:
- [x] Bumped chart version in Chart.yaml
- [x] Added an entry in the CHANGELOG.md
- [ ] Added an entry in the UPGRADE.md if this pull request creates a backward compatibility breaking change
- [ ] Reference your chart in the build matrix of the .travis.yml (For new charts)
