### PR TITLE
add services annotations and logging spec to peer and ord

### DIFF
--- a/hlf-ca/CHANGELOG.md
+++ b/hlf-ca/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.2] - 2022-02-17
+
+### Added
+- Added annotations to services
+
 ## [2.0.1] - 2021-09-09
 
 ### Added

--- a/hlf-ca/CHANGELOG.md
+++ b/hlf-ca/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.0.2] - 2022-02-17
+## [2.1.0] - 2022-02-17
 
 ### Added
 - Added annotations to services

--- a/hlf-ca/CHANGELOG.md
+++ b/hlf-ca/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added annotations to services
 
+### Changed
+- Allow initContainer image to get pass through from values.yaml. Useful incase a cluster has no access to public repositories
+
 ## [2.0.1] - 2021-09-09
 
 ### Added

--- a/hlf-ca/Chart.yaml
+++ b/hlf-ca/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: hlf-ca
-version: 2.0.2
+version: 2.1.0
 kubeVersion: ">= 1.19.0-0"
 description: Hyperledger Fabric Certificate Authority chart (these charts are forked from the one by AID:Tech and are currently not directly associated with them or Hyperledger project)
 type: application

--- a/hlf-ca/Chart.yaml
+++ b/hlf-ca/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: hlf-ca
-version: 2.0.1
+version: 2.0.2
 kubeVersion: ">= 1.19.0-0"
 description: Hyperledger Fabric Certificate Authority chart (these charts are forked from the one by AID:Tech and are currently not directly associated with them or Hyperledger project)
 type: application

--- a/hlf-ca/README.md
+++ b/hlf-ca/README.md
@@ -75,7 +75,7 @@ The following table lists the configurable parameters of the Hyperledger Fabric 
 | `image.pullPolicy`                 | Image pull policy                                | `IfNotPresent`                                             |
 | `service.annotations`              | Annotations for ca service                       | `{}`                                                       |
 | `service.port`                     | TCP port                                         | `7054`                                                     |
-| `service.type`                     | K8S service type exposing ports, e.g. `ClusterIP`| `ClusterIP`                                                |
+| `service.type`                     | K8S service type exposing ports, e.g. `ClusterIP`| `ClusterIP`                                              ZZ  |
 | `ingress.enabled`                  | If true, Ingress will be created                 | `false`                                                    |
 | `ingress.annotations`              | Ingress annotations                              | `{}`                                                       |
 | `ingress.path`                     | Ingress path                                     | `/`                                                        |

--- a/hlf-ca/README.md
+++ b/hlf-ca/README.md
@@ -73,6 +73,7 @@ The following table lists the configurable parameters of the Hyperledger Fabric 
 | `image.repository`                 | `hlf-ca` image repository                        | `hyperledger/fabric-ca`                                    |
 | `image.tag`                        | `hlf-ca` image tag                               | `1.4.3`                                                    |
 | `image.pullPolicy`                 | Image pull policy                                | `IfNotPresent`                                             |
+| `service.annotations`              | Annotations for ca service                       | `{}`                                                       |
 | `service.port`                     | TCP port                                         | `7054`                                                     |
 | `service.type`                     | K8S service type exposing ports, e.g. `ClusterIP`| `ClusterIP`                                                |
 | `ingress.enabled`                  | If true, Ingress will be created                 | `false`                                                    |

--- a/hlf-ca/README.md
+++ b/hlf-ca/README.md
@@ -73,9 +73,12 @@ The following table lists the configurable parameters of the Hyperledger Fabric 
 | `image.repository`                 | `hlf-ca` image repository                        | `hyperledger/fabric-ca`                                    |
 | `image.tag`                        | `hlf-ca` image tag                               | `1.4.3`                                                    |
 | `image.pullPolicy`                 | Image pull policy                                | `IfNotPresent`                                             |
+| `image.initContainer.repository`   | `dockerize` image repository                     | `jwilder/dockerize`                                        |
+| `image.initContainer.tag`          | `dockerize` image tag                            | `latest`                                                   |
+| `image.initContainer.pullPolicy`   | Image pull policy                                | `IfNotPresent`                                             |
 | `service.annotations`              | Annotations for ca service                       | `{}`                                                       |
 | `service.port`                     | TCP port                                         | `7054`                                                     |
-| `service.type`                     | K8S service type exposing ports, e.g. `ClusterIP`| `ClusterIP`                                              ZZ  |
+| `service.type`                     | K8S service type exposing ports, e.g. `ClusterIP`| `ClusterIP`                                                |
 | `ingress.enabled`                  | If true, Ingress will be created                 | `false`                                                    |
 | `ingress.annotations`              | Ingress annotations                              | `{}`                                                       |
 | `ingress.path`                     | Ingress path                                     | `/`                                                        |

--- a/hlf-ca/templates/deployment.yaml
+++ b/hlf-ca/templates/deployment.yaml
@@ -38,7 +38,7 @@ spec:
       initContainers:
         - name: wait-for-db
           image: "{{ .Values.initContainer.image.repository }}:{{ .Values.initContainer.image.tag }}"
-          imagePullPolicy: IfNotPresent
+          imagePullPolicy: {{ .Values.initContainer.pullPolicy }}
           envFrom:
             - configMapRef:
                 name: {{ include "hlf-ca.fullname" . }}--db

--- a/hlf-ca/templates/deployment.yaml
+++ b/hlf-ca/templates/deployment.yaml
@@ -38,7 +38,7 @@ spec:
       initContainers:
         - name: wait-for-db
           image: "{{ .Values.initContainer.image.repository }}:{{ .Values.initContainer.image.tag }}"
-          imagePullPolicy: {{ .Values.initContainer.pullPolicy }}
+          imagePullPolicy: {{ .Values.initContainer.image.pullPolicy }}
           envFrom:
             - configMapRef:
                 name: {{ include "hlf-ca.fullname" . }}--db

--- a/hlf-ca/templates/deployment.yaml
+++ b/hlf-ca/templates/deployment.yaml
@@ -37,7 +37,7 @@ spec:
             name: {{ include "hlf-ca.fullname" . }}--config
       initContainers:
         - name: wait-for-db
-          image: jwilder/dockerize
+          image: "{{ .Values.initContainer.image.repository }}:{{ .Values.initContainer.image.tag }}"
           imagePullPolicy: IfNotPresent
           envFrom:
             - configMapRef:

--- a/hlf-ca/templates/service.yaml
+++ b/hlf-ca/templates/service.yaml
@@ -4,6 +4,10 @@ metadata:
   name: {{ include "hlf-ca.fullname" . }}
   labels:
 {{ include "labels.standard" . | indent 4 }}
+  {{- if .Values.service.annotations }}
+  annotations:
+    {{- toYaml .Values.service.annotations | nindent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.service.type | quote }}
   ports:

--- a/hlf-ca/values.yaml
+++ b/hlf-ca/values.yaml
@@ -6,8 +6,14 @@ image:
   repository: hyperledger/fabric-ca
   tag: 1.4.3
   pullPolicy: IfNotPresent
+initContainer:
+  image:
+    repository: jwilder/dockerize
+    tag: latest
+    pullPolicy: IfNotPresent
 
 service:
+  annotations: {}
   ## Cluster IP or LoadBalancer
   type: ClusterIP
   port: 7054

--- a/hlf-couchdb/CHANGELOG.md
+++ b/hlf-couchdb/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.2] - 2022-02-17
+
+### Added
+- Added annotations to services
+
 ## [2.0.1] - 2021-09-09
 
 ### Added

--- a/hlf-couchdb/CHANGELOG.md
+++ b/hlf-couchdb/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.0.2] - 2022-02-17
+## [2.1.0] - 2022-02-17
 
 ### Added
 - Added annotations to services

--- a/hlf-couchdb/Chart.yaml
+++ b/hlf-couchdb/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: hlf-couchdb
-version: 2.0.1
+version: 2.0.2
 kubeVersion: ">= 1.19.0-0"
 description: CouchDB instance for Hyperledger Fabric (these charts are forked from the one by AID:Tech and are currently not directly associated with them or Hyperledger project)
 type: application

--- a/hlf-couchdb/Chart.yaml
+++ b/hlf-couchdb/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: hlf-couchdb
-version: 2.0.2
+version: 2.1.0
 kubeVersion: ">= 1.19.0-0"
 description: CouchDB instance for Hyperledger Fabric (these charts are forked from the one by AID:Tech and are currently not directly associated with them or Hyperledger project)
 type: application

--- a/hlf-couchdb/README.md
+++ b/hlf-couchdb/README.md
@@ -71,6 +71,7 @@ The following table lists the configurable parameters of the Hyperledger Fabric 
 | `image.repository`                 | `hlf-couchdb` image repository                   | `hyperledger/fabric-couchdb`                               |
 | `image.tag`                        | `hlf-couchdb` image tag                          | `x86_64-0.4.7`                                             |
 | `image.pullPolicy`                 | Image pull policy                                | `IfNotPresent`                                             |
+| `service.annotations`              | Annotations for couchdb service                  | `{}`                                                       |
 | `service.port`                     | TCP port                                         | `5984`                                                     |
 | `service.type`                     | K8S service type exposing ports, e.g. `ClusterIP`| `ClusterIP`                                                |
 | `persistence.accessMode`           | Use volume as ReadOnly or ReadWrite              | `ReadWriteOnce`                                            |

--- a/hlf-couchdb/templates/service.yaml
+++ b/hlf-couchdb/templates/service.yaml
@@ -4,6 +4,10 @@ metadata:
   name: {{ include "hlf-couchdb.fullname" . }}
   labels:
 {{ include "labels.standard" . | indent 4 }}
+  {{- if .Values.service.annotations }}
+  annotations:
+    {{- toYaml .Values.service.annotations | nindent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/hlf-couchdb/values.yaml
+++ b/hlf-couchdb/values.yaml
@@ -10,6 +10,7 @@ image:
   pullPolicy: IfNotPresent
 
 service:
+  annotations: {}
   type: ClusterIP
   port: 5984
 

--- a/hlf-ord/CHANGELOG.md
+++ b/hlf-ord/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [3.0.2] - 2022-02-17
+## [3.1.0] - 2022-02-17
 
 ### Added
 - Added `FABRIC_LOGGING_SPEC` to env through configmap which is the preferred mechanism for logging : https://hyperledger-fabric.readthedocs.io/en/release-2.2/logging-control.html#logging-specification

--- a/hlf-ord/CHANGELOG.md
+++ b/hlf-ord/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.0.2] - 2022-02-17
+
+### Added
+- Added `FABRIC_LOGGING_SPEC` to env through configmap which is the preferred mechanism for logging : https://hyperledger-fabric.readthedocs.io/en/release-2.2/logging-control.html#logging-specification
+- Added annotations to services
 
 ## [3.0.1] - 2021-09-09
 

--- a/hlf-ord/Chart.yaml
+++ b/hlf-ord/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: hlf-ord
-version: 3.0.1
+version: 3.0.2
 kubeVersion: ">= 1.19.0-0"
 description: Hyperledger Fabric Orderer chart (these charts are forked from the one by AID:Tech and are currently not directly associated with them or Hyperledger project)
 type: application

--- a/hlf-ord/Chart.yaml
+++ b/hlf-ord/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: hlf-ord
-version: 3.0.2
+version: 3.1.0
 kubeVersion: ">= 1.19.0-0"
 description: Hyperledger Fabric Orderer chart (these charts are forked from the one by AID:Tech and are currently not directly associated with them or Hyperledger project)
 type: application

--- a/hlf-ord/README.md
+++ b/hlf-ord/README.md
@@ -90,6 +90,7 @@ The following table lists the configurable parameters of the Hyperledger Fabric 
 | `image.repository`                 | `hlf-ord` image repository                                    | `hyperledger/fabric-orderer`                               |
 | `image.tag`                        | `hlf-ord` image tag                                           | `x86_64-1.1.0`                                             |
 | `image.pullPolicy`                 | Image pull policy                                             | `IfNotPresent`                                             |
+| `service.annotations`              | Annotations for orderer service                               | `{}`                                                       |
 | `service.port`                     | TCP port                                                      | `7050`                                                     |
 | `service.type`                     | K8S service type exposing ports, e.g. `ClusterIP`             | `ClusterIP`                                                |
 | `service.portMetrics`              | TCP port for the metrics service                              | `9443`                                                     |
@@ -106,6 +107,7 @@ The following table lists the configurable parameters of the Hyperledger Fabric 
 | `persistence.storageClass`         | Storage class of backing PVC                                  | `default`                                                  |
 | `ord.type`                         | Type of Orderer (`solo`, `etcdraft` or `kafka`)               | `solo`                                                     |
 | `ord.mspID`                        | ID of MSP the Orderer belongs to                              | `OrdererMSP`                                               |
+| `logging.spec`                     | Fabric logging specs                                          | ``                                                         |
 | `ord.tls.server.enabled`           | Do we enable server-side TLS?                                 | `false`                                                    |
 | `ord.tls.client.enabled`           | Do we enable client-side TLS?                                 | `false`                                                    |
 | `ord.metrics.provider`             | Metrics provider, can be `statsd`, `prometheus` or `disabled` | `disabled`                                                 |

--- a/hlf-ord/templates/configmap--ord.yaml
+++ b/hlf-ord/templates/configmap--ord.yaml
@@ -37,6 +37,10 @@ data:
   ORDERER_GENERAL_CLUSTER_ROOTCAS: "/var/hyperledger/tls/server/cert/cacert.pem"
   GODEBUG: "netdns=go"
   ADMIN_MSP_PATH: /var/hyperledger/admin_msp
+  ###########
+  # Logging #
+  ###########
+  FABRIC_LOGGING_SPEC: {{ .Values.logging.spec | quote }}
   ##############
   # Operations #
   ##############

--- a/hlf-ord/templates/service.yaml
+++ b/hlf-ord/templates/service.yaml
@@ -4,6 +4,10 @@ metadata:
   name: {{ include "hlf-ord.fullname" . }}
   labels:
 {{ include "labels.standard" . | indent 4 }}
+  {{- if .Values.service.annotations }}
+  annotations:
+    {{- toYaml .Values.service.annotations | nindent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/hlf-ord/values.yaml
+++ b/hlf-ord/values.yaml
@@ -8,6 +8,7 @@ image:
   pullPolicy: IfNotPresent
 
 service:
+  annotations: {}
   # Cluster IP or LoadBalancer
   type: ClusterIP
   port: 7050
@@ -44,6 +45,8 @@ persistence:
   size: 1Gi
   # existingClaim: ""
 
+logging:
+  spec: ""
 ##################################
 ## Orderer configuration options #
 ##################################

--- a/hlf-peer/CHANGELOG.md
+++ b/hlf-peer/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [5.0.1] - 2022-02-17
+## [5.1.0] - 2022-02-17
 
 ### Added
 - Added `FABRIC_LOGGING_SPEC` to env through configmap which is the preferred mechanism for logging : https://hyperledger-fabric.readthedocs.io/en/release-2.2/logging-control.html#logging-specification

--- a/hlf-peer/CHANGELOG.md
+++ b/hlf-peer/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.0.1] - 2022-02-17
+
+### Added
+- Added `FABRIC_LOGGING_SPEC` to env through configmap which is the preferred mechanism for logging : https://hyperledger-fabric.readthedocs.io/en/release-2.2/logging-control.html#logging-specification
+- Added annotations to services
 
 ## [5.0.0] - 2021-10-13
 

--- a/hlf-peer/Chart.yaml
+++ b/hlf-peer/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: hlf-peer
-version: 5.0.1
+version: 5.1.0
 kubeVersion: ">= 1.19.0-0"
 description: Hyperledger Fabric Peer chart (these charts are forked from the one by AID:Tech and are currently not directly associated with them or Hyperledger project)
 type: application

--- a/hlf-peer/Chart.yaml
+++ b/hlf-peer/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: hlf-peer
-version: 5.0.0
+version: 5.0.1
 kubeVersion: ">= 1.19.0-0"
 description: Hyperledger Fabric Peer chart (these charts are forked from the one by AID:Tech and are currently not directly associated with them or Hyperledger project)
 type: application

--- a/hlf-peer/README.md
+++ b/hlf-peer/README.md
@@ -77,6 +77,7 @@ The following table lists the configurable parameters of the Hyperledger Fabric 
 | `image.tag`                         | `hlf-peer` image tag                                           | `1.4.3`                   |
 | `image.pullPolicy`                  | Image pull policy                                              | `IfNotPresent`            |
 | `image.pullImageSecret`             | Image pull secret name                                         |  `nil`                    |
+| `service.annotations`               | Annotations for peer service                                   | `{}`                      |
 | `service.portRequest`               | TCP port for requests to Peer                                  | `7051`                    |
 | `service.portEvent`                 | TCP port for event service on Peer                             | `7053`                    |
 | `service.portMetrics`               | TCP port for the metrics service on Peer                       | `9443`                    |
@@ -93,6 +94,7 @@ The following table lists the configurable parameters of the Hyperledger Fabric 
 | `logging.ledger`                    | Ledger logging level                                           | `info`                    |
 | `logging.msp`                       | MSP logging level                                              | `warning`                 |
 | `logging.policies`                  | Policies logging level                                         | `warning`                 |
+| `logging.spec`                      | Fabric logging specs                                           | ``                        |
 | `ingress.enabled`                   | If true, Ingress will be created                               | `false`                   |
 | `ingress.annotations`               | Ingress annotations                                            | `{}`                      |
 | `ingress.ingressClassName`          | Ingress class that will be used for the ingress                | `nil`                     |

--- a/hlf-peer/templates/configmap--peer.yaml
+++ b/hlf-peer/templates/configmap--peer.yaml
@@ -25,6 +25,7 @@ data:
   ###########
   # Logging #
   ###########
+  FABRIC_LOGGING_SPEC: {{ .Values.logging.spec | quote }}
   CORE_LOGGING_LEVEL: {{ .Values.logging.level | quote }}
   CORE_LOGGING_PEER: {{ .Values.logging.peer | quote }}
   CORE_LOGGING_CAUTHDSL: {{ .Values.logging.cauthdsl | quote }}

--- a/hlf-peer/templates/service.yaml
+++ b/hlf-peer/templates/service.yaml
@@ -4,6 +4,10 @@ metadata:
   name: {{ include "hlf-peer.fullname" . }}
   labels:
 {{ include "labels.standard" . | indent 4 }}
+  {{- if .Values.service.annotations }}
+  annotations:
+    {{- toYaml .Values.service.annotations | nindent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/hlf-peer/values.yaml
+++ b/hlf-peer/values.yaml
@@ -9,6 +9,7 @@ image:
   # pullImageSecret: docker-config
 
 service:
+  annotations: {}
   # Cluster IP or LoadBalancer
   type: ClusterIP
   portRequest: 7051
@@ -63,6 +64,7 @@ logging:
   ledger: info
   msp: warning
   policies: warning
+  spec: ""
 
 
 ##################################


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR addresses 3 issues: 

- Adding annotations to services which are useful by some workloads monitoring the service

- Using fabric logging spec for ord/peer which is the preferred log level mechanism

- Allow the use of initContainer image passthrough for hlf-ca. Useful if cluster does not have access to public image repositories.

**Which issue(s) this PR fixes**:

https://github.com/owkin/charts/issues/45

https://github.com/owkin/charts/issues/44

**Special notes for your reviewer**:

**Checklist**:
- [ X] Bumped chart version in Chart.yaml
- [ X] Added an entry in the CHANGELOG.md
- [ ] Added an entry in the UPGRADE.md if this pull request creates a backward compatibility breaking change
- [ ] Reference your chart in the build matrix of the .travis.yml (For new charts)
