### PR TITLE
feat: enable reenrollIgnoreCertExpiry

### DIFF
--- a/hlf-ca/CHANGELOG.md
+++ b/hlf-ca/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+## [2.1.0] - 2022-02-18
+
+### Added
+- Set `reenrollIgnoreCertExpiry` to `true` in the configuration
+
+### Changed
+- Update fabric-ca and fabric-tools to `1.5.1`
+
 ## [2.0.1] - 2021-09-09
 
 ### Added

--- a/hlf-ca/Chart.yaml
+++ b/hlf-ca/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: hlf-ca
-version: 2.0.1
+version: 2.1.0
 kubeVersion: ">= 1.19.0-0"
 description: Hyperledger Fabric Certificate Authority chart (these charts are forked from the one by AID:Tech and are currently not directly associated with them or Hyperledger project)
 type: application
@@ -21,4 +21,4 @@ maintainers:
   - name: Kelvin-M
     email: kelvin.moutet@owkin.com
 icon: https://www.hyperledger.org/wp-content/uploads/2018/04/fabric-logo.png
-appVersion: 1.4.3
+appVersion: 1.5.1

--- a/hlf-ca/templates/configmap--config.yaml
+++ b/hlf-ca/templates/configmap--config.yaml
@@ -50,6 +50,8 @@ data:
       certfile: /var/hyperledger/fabric-ca/msp/certs/{{ include "hlf-ca.fullname" . }}-cert.pem
       # Chain file
       chainfile:
+      # Ignore Certificate Expiration in the case of re-enroll
+      reenrollIgnoreCertExpiry: true
     #############################################################################
     #  The gencrl REST endpoint is used to generate a CRL that contains revoked
     #  certificates. This section contains configuration options that are used

--- a/hlf-ca/values.yaml
+++ b/hlf-ca/values.yaml
@@ -4,7 +4,7 @@
 
 image:
   repository: hyperledger/fabric-ca
-  tag: 1.4.3
+  tag: 1.5.1
   pullPolicy: IfNotPresent
 
 service:
@@ -76,7 +76,7 @@ externalDatabase:
 
 ## Settings used in configMap "--config"
 config:
-  hlfToolsVersion: 1.4.3
+  hlfToolsVersion: 1.5.1
   ## Mount the TLS certificate & key to disk?
   mountTLS: false
   ## Enable debug logging in ca Server configuration file


### PR DESCRIPTION
**What this PR does / why we need it**:
<!--  Thanks for sending a pull request! Please add at least a small note here to explain what the change does: -->

Update hlf-ca chart to use fabric-ca 1.5.1 (https://github.com/hyperledger/fabric-ca/releases/tag/v1.5.1) in order to be able to use `reenrollIgnoreCertExpiry`

**Special notes for your reviewer**:

**Checklist**:
- [x] Bumped chart version in Chart.yaml
- [x] Added an entry in the CHANGELOG.md
- [ ] Added an entry in the UPGRADE.md if this pull request creates a backward compatibility breaking change
- [ ] Reference your chart in the build matrix of the .travis.yml (For new charts)
