### PR TITLE
feat(pypiserver): external secret with credentials

### DIFF
--- a/pypiserver/CHANGELOG.md
+++ b/pypiserver/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.1.0]
+
+### Added
+- Ability to provide external Secret with credentials
+
 ## [3.0.1]
 
 ### Changed

--- a/pypiserver/Chart.yaml
+++ b/pypiserver/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: pypiserver
-version: 3.0.1
+version: 3.1.0
 kubeVersion: ">= 1.19.0-0"
 description: PyPI compatible server for pip or easy_install.
 type: application

--- a/pypiserver/README.md
+++ b/pypiserver/README.md
@@ -50,6 +50,7 @@ The following tables lists the configurable parameters of the PyPI server chart 
 | `pypiserver.extraArgs`             | Additional arguments (beside -P, -p, -a) to be passed to the underyling pypiserver image | `[]`                    |
 | `auth.actions`                     | Actions requiring authentication (comma separated list)                                  | `update`                |
 | `auth.credentials`                 | Map of username / encoded password to write in a htpasswd file                           | `{}`                    |
+| `auth.existingSecret`              | Name of externally provided secret with credentials                                      | `""`                    |
 | `ingress.enabled`                  | Ingress configuration flag                                                               | `false`                 |
 | `ingress.ingressClassName`         | Ingress class name                                                                       | `nil`                   |
 | `ingress.labels`                   | Ingress labels                                                                           | `{}`                    |

--- a/pypiserver/templates/deployment.yaml
+++ b/pypiserver/templates/deployment.yaml
@@ -84,7 +84,7 @@ spec:
       volumes:
         - name: secrets
           secret:
-            secretName: {{ template "pypiserver.fullname" . }}
+            secretName: {{ if .Values.auth.existingSecret }}{{ .Values.auth.existingSecret }}{{- else }}{{ template "pypiserver.fullname" . }}{{- end }}
         - name: packages
         {{- if .Values.persistence.enabled }}
           persistentVolumeClaim:

--- a/pypiserver/templates/secret.yaml
+++ b/pypiserver/templates/secret.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.auth.existingSecret -}}
 apiVersion: v1
 kind: Secret
 type: Opaque
@@ -13,3 +14,4 @@ metadata:
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/pypiserver/values.yaml
+++ b/pypiserver/values.yaml
@@ -21,6 +21,8 @@ auth:
   ## Map of username / encoded passwords that will be put to the htpasswd file
   ## use `htpasswd -n -b username password` to generate them
   credentials: {}
+  ## Name of externally provided secret with credentials
+  existingSecret: ""
 
 podAnnotations: {}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds possibility to declare existing secret for pypi server auth.

**Which issue(s) this PR fixes**:
Fixes #48 

**Special notes for your reviewer**:

**Checklist**:
- [x] Bumped chart version in Chart.yaml
- [x] Added an entry in the CHANGELOG.md
- [n/a] Added an entry in the UPGRADE.md if this pull request creates a backward compatibility breaking change
- [n/a] Reference your chart in the build matrix of the .travis.yml (For new charts)
