### PR TITLE
Expose timeouts for probes in values

### DIFF
--- a/pypiserver/CHANGELOG.md
+++ b/pypiserver/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.1.1]
+
+### Added
+- Ability to specify timeouts for readiness and livenss probes
+
 ## [3.1.0]
 
 ### Added

--- a/pypiserver/Chart.yaml
+++ b/pypiserver/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: pypiserver
-version: 3.1.0
+version: 3.1.1
 kubeVersion: ">= 1.19.0-0"
 description: PyPI compatible server for pip or easy_install.
 type: application

--- a/pypiserver/templates/deployment.yaml
+++ b/pypiserver/templates/deployment.yaml
@@ -70,14 +70,14 @@ spec:
               path: /
               port: http
             initialDelaySeconds: 30
-            timeoutSeconds: 5
+            timeoutSeconds: {{ .Values.livenessTimeout }}
             failureThreshold: 6
           readinessProbe:
             httpGet:
               path: /
               port: http
             initialDelaySeconds: 5
-            timeoutSeconds: 3
+            timeoutSeconds: {{ .Values.readinessTimeout }}
             periodSeconds: 5
           resources:
             {{- toYaml .Values.resources | nindent 12 }}

--- a/pypiserver/values.yaml
+++ b/pypiserver/values.yaml
@@ -28,6 +28,10 @@ podAnnotations: {}
 
 podLabels: {}
 
+# Timeouts for liveness and readiness probes
+livenessTimeout: 5
+readinessTimeout: 3
+
 ingress:
   enabled: false
   ingressClassName:


### PR DESCRIPTION
**What this PR does / why we need it**:
In my deployment, it can take longer than 5s to service some requests. I believe this is due to limitations
of the filesystem where the distributions are mounted from, and the number of distributions we have, so I can't do much about it.

This means my pods are regularly failing liveness checks and getting restarted when they are actually just busy.

I wish to set longer timeouts but there is no way to do this in the chart currently.

I am suggesting to expose the timeouts as values.

**Which issue(s) this PR fixes**:
I haven't made an issue, let me know if I should.

**Special notes for your reviewer**:

**Checklist**:
- [ /] Bumped chart version in Chart.yaml
- [ /] Added an entry in the CHANGELOG.md
- [ n/a ] Added an entry in the UPGRADE.md if this pull request creates a backward compatibility breaking change
- [ n/a ] Reference your chart in the build matrix of the .travis.yml (For new charts)
